### PR TITLE
Fixes tasks do not inherit environment variables from shell

### DIFF
--- a/foremon/__init__.py
+++ b/foremon/__init__.py
@@ -1,2 +1,2 @@
 from .monitor import Monitor
-__version__ = "1.1.2"
+__version__ = "1.1.3"

--- a/foremon/config.py
+++ b/foremon/config.py
@@ -1,7 +1,7 @@
 import os
 import signal
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, MutableMapping, Optional
 
 import toml
 from pydantic import BaseSettings, Field, validator
@@ -67,6 +67,11 @@ class ForemonConfig(BaseSettings):
             elif isinstance(value, str):
                 value = os.path.expandvars(value)
         return value
+
+    def get_env(self) -> MutableMapping[str, str]:
+        env = os.environ.copy()
+        env.update(self.environment)
+        return env
 
     class Config:
         env_prefix = 'foremon_'

--- a/foremon/task.py
+++ b/foremon/task.py
@@ -3,7 +3,7 @@ import atexit
 import weakref
 from asyncio.base_events import BaseEventLoop
 from asyncio.subprocess import Process, create_subprocess_shell
-from typing import Awaitable, Callable, Coroutine, List, Optional, Set, Tuple
+from typing import Awaitable, Callable, Coroutine, List, MutableMapping, Optional, Set, Tuple
 
 from .config import ForemonConfig
 from .display import *
@@ -162,7 +162,7 @@ class ForemonTask:
             try:
                 self.process = await create_subprocess_shell(
                     script, stdout=sys.stdout, stderr=sys.stderr,
-                    shell=True, env=self.config.environment)
+                    shell=True, env=self.config.get_env())
 
                 last_pid = self.process.pid
 

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -211,11 +211,13 @@ def test_task_add_monitor_duplicate():
         mon.add_task(task)
 
 
-async def test_task_passes_environment(output: CapLines):
+async def test_task_passes_environment(output: CapLines, monkeypatch):
+
+    monkeypatch.setenv('INHERITS', 'test456', prepend=False)
 
     conf = PyProjectConfig.parse_toml("""
     [tool.foremon]
-    scripts = ["echo DATA=$MYVAR"]
+    scripts = ["echo DATA=$MYVAR", "echo DATA=$INHERITS"]
     [tool.foremon.environment]
     MYVAR = "test123"
     """).tool.foremon
@@ -223,3 +225,4 @@ async def test_task_passes_environment(output: CapLines):
     await ForemonTask(conf).run()
 
     output.stdout_expect("DATA=test123")
+    output.stdout_expect("DATA=test456")


### PR DESCRIPTION
### Fixes

- Fixes tasks do not inherit environment variables from shell.