### PR TITLE
Ensures config change terminate running scripts before reload

### DIFF
--- a/config/parallel.toml
+++ b/config/parallel.toml
@@ -3,9 +3,9 @@
 [tool.foremon]
 
     [tool.foremon.t1]
-    paths = ["trigger.txt"]
-    scripts = ["for i in 1 2 3; do echo T1 $i; sleep 1; done"]
+    paths = ["tests/input/$TEMPDIR/trigger.txt"]
+    scripts = ["for i in 1 2 3; do echo T1 $$ $i; sleep 1; done"]
 
     [tool.foremon.t2]
-    paths = ["trigger.txt"]
-    scripts = ["for i in 1 2 3 4 5 6; do echo T2 $i; sleep 1; done"]
+    paths = ["tests/input/$TEMPDIR/trigger.txt"]
+    scripts = ["for i in 1 2 3 4 5 6; do echo T2 $$ $i; sleep 1; done"]

--- a/foremon/app.py
+++ b/foremon/app.py
@@ -178,6 +178,7 @@ class Foremon:
     def reload(self):
         # pause events
         with self.monitor.paused():
+            self.monitor.terminate_tasks()
             self.monitor.reset()
             self.load_config()
             self.reset_monitor()


### PR DESCRIPTION
### Fixed 

- Issue #6 - config auto-reload causes scripts to run in parallel