### PR TITLE
Module detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ foremon -h
 ```
 
 Using foremon is simple. It will guess if you are running a module or python
-script and adjust the command-line arguments accordingly. To disable this
-feature, add the `-n` (`--no-guess`) option.
+script and adjust command-line arguments and the `PYTHONPATH` accordingly. To
+disable this feature, add the `-n` (`--no-guess`) option.
 
 ```bash
 # Executes `script.py`
@@ -67,9 +67,14 @@ foremon -n -- script.py
 # Executes `python3 script.py`
 foremon -- script.py
 
-# Does not try to guess command. `test` is ambiguous because it is a
-# shell-builtin and python module.
-foremon -- test -f script.py
+# Executes `python -m module` if module/__main__.py is present
+foremon module
+
+# Executes `python -c 'from lib import main; main()'` if only lib/__init__.py is present
+foremon lib:main
+
+# Execute `python -m module` and inserts `path/to` into PYTHONPATH
+foremon path/to/module
 ```
 
 foremon runs python scripts with the python interpreter of the environment it is

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ foremon will bootstrap your module or script with the arguments you normally
 pass to it:
 
 ```bash
-foremon [script or module] [args]
+foremon [script or module or library:func] [args]
 ```
 
 If your application uses options which conflict with foremon's options use the

--- a/foremon/app.py
+++ b/foremon/app.py
@@ -9,7 +9,7 @@ from foremon.config import *
 from foremon.display import *
 from foremon.monitor import Monitor
 from foremon.task import ForemonTask, ScriptTask
-from foremon.util import guess_args, relative_if_cwd
+from foremon.util import guess_and_update_scripts, guess_args, relative_if_cwd
 
 DEFAULT_CONFIG = op.join(os.getcwd(), "pyproject.toml")
 AUTO_RELOAD_ALIAS = 'foremon-auto-reload'
@@ -120,11 +120,12 @@ class Foremon:
         c: ForemonConfig = self.config
         o: ForemonOptions = self.options
 
-        if not o.no_guess:
-            args = list(map(guess_args, o.scripts))
-            c.scripts.extend(args)
-        else:
+        if o.scripts:
             c.scripts.extend(o.scripts)
+
+        if not o.no_guess:
+            guess_and_update_scripts(c)
+
         if o.unsafe:
             c.ignore_defaults.clear()
         if o.cwd:

--- a/foremon/app.py
+++ b/foremon/app.py
@@ -9,7 +9,7 @@ from foremon.config import *
 from foremon.display import *
 from foremon.monitor import Monitor
 from foremon.task import ForemonTask, ScriptTask
-from foremon.util import guess_and_update_scripts, guess_args, relative_if_cwd
+from foremon.util import guess_and_update_scripts, relative_if_cwd
 
 DEFAULT_CONFIG = op.join(os.getcwd(), "pyproject.toml")
 AUTO_RELOAD_ALIAS = 'foremon-auto-reload'

--- a/foremon/util.py
+++ b/foremon/util.py
@@ -1,8 +1,11 @@
+from foremon.config import ForemonConfig
 import os
+from posixpath import dirname
 import sys
 import os.path as op
 import shlex
 from importlib.util import find_spec
+
 
 def relative_if_cwd(path: str) -> str:
     """
@@ -12,6 +15,78 @@ def relative_if_cwd(path: str) -> str:
     if path.startswith(cwd):
         return op.relpath(path)
     return path
+
+
+def guess_and_update_scripts(config: ForemonConfig):
+    """
+    Guess how to mutate arguments to conveniently execute python scripts or
+    modules.
+
+    This mutation is only applied to the default config.
+
+    Cases handled:
+
+    foremon script.py -> python script.py
+    foremon script.py -> script.py (when script.py is executable)
+    foremon module -> python -m module (if __main__ present)
+    foremon path/to/module -> python -m module (PYTHONPATH=path/to if __main__ present)
+    foremon module:main ->  python -c 'from module import main; main()' (if __init__ present but no __main__)
+    foremon path/to/module:main ->  python -c 'from module import main; main()' (if __init__ present but no __main__)
+    """
+
+    if not config.scripts:
+        return
+
+    # Only applies to last script, other scripts are defined by the `-x` option.
+    python = relative_if_cwd(sys.executable)
+    script = config.scripts[-1]
+    new_script = None
+    args = shlex.split(script)
+    if not args:
+        return
+
+    arg0 = args[0]
+    func = None
+
+    # handle `module:function` declarations
+    if ':' in arg0:
+        arg0, func = arg0.rsplit(':', 1)
+
+    # remove trailing /
+    arg0 = arg0.rstrip(op.sep)
+    dirname = op.dirname(arg0)
+    basename = op.basename(arg0)
+
+    if arg0.endswith('.py'):
+        # Attempt to insert python interpreter before script path if script is not executable
+        if not os.access(arg0, os.X_OK):
+            args.insert(0, python)
+        new_script = ' '.join(args)
+    elif op.isdir(arg0):
+        # Invoke as `python -m directory` and update PYTHONPATH
+        if op.isfile(op.join(arg0, '__main__.py')):
+
+            args = [python, '-m', basename] + args[1:]
+            new_script = ' '.join(args)
+
+        # Invoke as `python -c 'from basename import func; func()'`
+        elif func and op.isfile(op.join(arg0, '__init__.py')):
+            py_script = f'from {basename} import {func}; {func}()'
+            args = [python, '-c', shlex.quote(py_script)] + args[1:]
+            new_script = ' '.join(args)
+
+        if new_script and dirname:
+            python_path = config.environment.get('PYTHONPATH', '')
+            python_path = python_path.split(op.pathsep)
+            python_path.insert(0, dirname)
+            config.environment['PYTHONPATH'] = op.sep.join(python_path)
+    elif find_spec(arg0) is not None:
+        args = [python, '-m', basename] + args[1:]
+        new_script = ' '.join(args)
+
+    if new_script:
+        # Replace the original script
+        config.scripts[-1] = new_script
 
 
 def guess_args(args: str) -> str:

--- a/foremon/util.py
+++ b/foremon/util.py
@@ -87,33 +87,3 @@ def guess_and_update_scripts(config: ForemonConfig):
     if new_script:
         # Replace the original script
         config.scripts[-1] = new_script
-
-
-def guess_args(args: str) -> str:
-    if not args:
-        return args
-    argv = shlex.split(args)
-    if not argv:
-        return args
-
-    arg0: str = argv[0]
-
-    if arg0.endswith('.py'):
-        # Attempt to insert python interpreter before script path if script is not executable
-        is_x = os.access(arg0, os.X_OK)
-        if not is_x:
-            argv.insert(0, relative_if_cwd(sys.executable))
-        # Attempt to insert `python -m` before module name if arg[0] is dir
-    elif op.isdir(arg0):
-        init_file = op.join(arg0, '__main__.py')
-        if op.isfile(init_file):
-            argv = [relative_if_cwd(sys.executable), '-m'] + argv
-
-    else:
-        # Attempt run as module that isn't local
-        spec = find_spec(arg0)
-        if spec is not None:
-            argv = [relative_if_cwd(sys.executable), '-m'] + argv
-
-    # shlex.join not in py3.7
-    return " ".join(argv)

--- a/tests/samples/module2/__init__.py
+++ b/tests/samples/module2/__init__.py
@@ -1,0 +1,12 @@
+import sys
+import json
+
+text = json.dumps(dict(
+  executable=sys.executable,
+  argv=sys.argv,
+  name=__name__
+), indent=2)
+
+
+def main():
+  print(text)

--- a/tests/samples/server/__main__.py
+++ b/tests/samples/server/__main__.py
@@ -1,0 +1,13 @@
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+def run(server_class=HTTPServer, handler_class=BaseHTTPRequestHandler):
+    server_address = ('', 0)
+    httpd = server_class(server_address, handler_class)
+    httpd.serve_forever()
+
+if __name__ == '__main__':
+    print('starting ...')
+    try:
+        run()
+    except KeyboardInterrupt:
+        print('\rstopped')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -130,7 +130,7 @@ def test_cli_guess_script(noninteractive: MagicMock, cli):
     assert op.basename(sys.executable) in guess
 
 
-def test_cli_guess_module(noninteractive: MagicMock, cli):
+def test_cli_guess_module1(noninteractive: MagicMock, cli):
 
     cli(get_sample_file('module1'))
 
@@ -138,6 +138,18 @@ def test_cli_guess_module(noninteractive: MagicMock, cli):
     assert f
     guess = f.config.scripts[0]
     assert op.basename(sys.executable) + ' -m' in guess
+
+def test_cli_guess_module2(noninteractive: MagicMock, cli: CliProg):
+
+    arg = get_sample_file('module2') + ":main"
+    res = cli(arg)
+    assert res.exit_code == 0
+
+    f: Foremon = noninteractive.call_args[0][0]
+    assert f
+
+    guess = f.config.scripts[0]
+    assert op.basename(sys.executable) + ' -c' in guess
 
 def test_cli_guess_modules_in_env(noninteractive: MagicMock, cli):
 

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -5,7 +5,7 @@ import os
 import signal
 
 from foremon.config import *
-from foremon.display import display_info
+from foremon.display import display_info, display_success
 from foremon.task import ScriptTask
 from pydantic.error_wrappers import ValidationError
 
@@ -234,6 +234,7 @@ async def test_task_callback_throws(output: CapLines):
     """).tool.foremon
 
     def thrower(*args):
+        display_success("throwing exception for test ...")
         raise ForemonError('error')
 
     await ScriptTask(conf).add_before_callback(thrower).run()


### PR DESCRIPTION
### Added

- CLI can run modules without `__main__.py` using `[module]:[function]` syntax (see README).