### PR TITLE
v1.3.0

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "args": ["-k", "test_config_order", "-s"],
+            "console": "integratedTerminal",
+            "cwd": "${workspaceFolder}",
+            "name": "PyTest",
+            "program": "${workspaceFolder}/.venv/bin/pytest",
+            "request": "launch",
+            "type": "python",
+          },
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -97,9 +97,9 @@ foremon will wait a short period after changes are detected before restarting
 scripts. If a high volume of events are preventing a script from being restarted
 foremon will display a warning.
 
-To control how long foremon waits use the `-d/--dwell` option or set `dwell` in
-the config file. _Dwell_ is a fractional number of seconds to wait, and set to
-`0.1` (_100 milliseconds_) by default.
+To control how long foremon waits use the `-d/--dwell` option. _Dwell_ is a
+fractional number of seconds to wait and is set to `0.1` (_100 milliseconds_) by
+default.
 
 # Manual restart
 

--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ If your application uses options which conflict with foremon's options use the
 foremon -- mymodules --version
 ```
 
-For CLI options, use `-h` or `--help`:
+For CLI options `--help`:
 
 ```bash
-foremon -h
+foremon --help
 ```
 
 Using foremon is simple. It will guess if you are running a module or python
@@ -89,9 +89,17 @@ found, will run scripts specified in the `[tool.foremon]` section
 
 # Automatic re-running
 
-When file changes are detected foremon will restart the script. If scripts are
-still running when the change is detected, foremon will ignore the event until
-the script completes and a new change occurs.
+When file changes are detected foremon will restart the script. If a script is
+running when the change is detected foremon will terminate the script before
+running it again.
+
+foremon will wait a short period after changes are detected before restarting
+scripts. If a high volume of events are preventing a script from being restarted
+foremon will display a warning.
+
+To control how long foremon waits use the `-d/--dwell` option or set `dwell` in
+the config file. _Dwell_ is a fractional number of seconds to wait, and set to
+`0.1` (_100 milliseconds_) by default.
 
 # Manual restart
 
@@ -104,8 +112,6 @@ foremon can also be shutdown gracefully by typing `exit` followed by `enter`.
 Just using `ctrl+c` has the same effect.
 
 # pyproject.toml
-
-> support for pyproject.toml
 
 foremon supports _pyproject.toml_ configuration files. If the project contains a
 _pyproject.toml_ file foremon will automatically load defaults from the
@@ -128,11 +134,10 @@ scripts = ["pytest --cov=myproj"]
 skip = true
 # Run script like they're in this directory
 cwd = "./"
-# Key-Value paris of environment variables
-[tool.foremon.environment]
-TERM = "MONO"
 # Exit code to expect for a successful exit
 returncode = 0
+# Amount of time after an event is received and a script is restarted
+dwell = 1.0
 # Signal to send if the process should be terminated
 term_signal = "SIGTERM"
 # Set to false to turn on case-sensitive pattern matching
@@ -149,6 +154,9 @@ paths = ["src/"]
 recursive = true
 # List of events - created, deleted, moved, modified
 events = ["created", "modified"]
+# Environment overrides
+[tool.foremon.environment]
+TERM = "MONO"
 ```
 
 All subsections contain the same options.

--- a/config/sanity-check.toml
+++ b/config/sanity-check.toml
@@ -5,10 +5,11 @@
 
     [tool.foremon.test1]
     patterns = ["*TEST1"]
-    paths = ["tests/input"]
+    # TEMPDIR is set in the tests/expect/docker.sh script
+    paths = ["$TEMPDIR", "tests/input"]
     scripts = [ "echo trigger-1"]
 
     [tool.foremon.test2]
     patterns = ["*TEST2"]
-    paths = ["tests/input"]
+    paths = ["$TEMPDIR", "tests/input"]
     scripts = [ "echo trigger-2"]

--- a/foremon/__init__.py
+++ b/foremon/__init__.py
@@ -1,2 +1,2 @@
 from .monitor import Monitor
-__version__ = "1.2.1"
+__version__ = "1.3.0"

--- a/foremon/cli.py
+++ b/foremon/cli.py
@@ -82,6 +82,9 @@ def print_version(ctx: Context, param, value):
 @click.option('--reload/--no-reload', 'auto_reload',
               is_flag=True, default=True,
               help='Automatically reload the config if it changes.')
+@click.option('-d', '--dwell', type=float,
+              default=0.1, show_default=True,
+              help='Dwell this long after a change is detect to restart a script.')
 @click.argument('args', callback=want_string, nargs=-1)
 def foremon(verbose: bool, args: str, scripts: List[str], version=None, **kwargs):
 

--- a/foremon/cli.py
+++ b/foremon/cli.py
@@ -82,7 +82,7 @@ def print_version(ctx: Context, param, value):
 @click.option('--reload/--no-reload', 'auto_reload',
               is_flag=True, default=True,
               help='Automatically reload the config if it changes.')
-@click.option('-d', '--dwell', type=float,
+@click.option('-d', '--dwell', type=click.FloatRange(min=0.0, clamp=True),
               default=0.1, show_default=True,
               help='Dwell this long after a change is detect to restart a script.')
 @click.argument('args', callback=want_string, nargs=-1)

--- a/foremon/config.py
+++ b/foremon/config.py
@@ -138,7 +138,7 @@ class ForemonOptions(BaseModel):
     use_all: bool = Field(False)
     verbose: bool = Field(False)
     auto_reload: bool = Field(True)
-    dwell:float = Field(0.1)
+    dwell: float = Field(0.1)
 
 
 __all__ = ['PyProjectConfig', 'ToolConfig', 'ForemonConfig', 'Events', 'ForemonOptions']

--- a/foremon/config.py
+++ b/foremon/config.py
@@ -1,11 +1,12 @@
 import os
 import signal
 from enum import Enum
+from itertools import count
 from typing import Any, Dict, List, MutableMapping, Optional
-from pydantic.main import BaseModel
 
 import toml
 from pydantic import BaseSettings, Field, validator
+from pydantic.main import BaseModel
 
 DEFAULT_IGNORES = [
     # Some of these are redundant
@@ -25,9 +26,24 @@ class Events(str, Enum):
     moved = 'moved'
 
 
+Increment = count(start=0)
+
+
+def NextIncrement():
+    global Increment
+    val = next(Increment)
+    return val
+
+
+def SetIncrement(start: int = 0):
+    global Increment
+    Increment = count(start=start)
+
+
 class ForemonConfig(BaseSettings):
 
-    alias:           str = Field('')
+    alias: str = Field('')
+    order: Optional[int]
 
     ################################
     # Script execution
@@ -69,10 +85,21 @@ class ForemonConfig(BaseSettings):
                 value = os.path.expandvars(value)
         return value
 
-    def get_env(self) -> MutableMapping[str, str]:
-        env = os.environ.copy()
-        env.update(self.environment)
-        return env
+    @validator('order')
+    def validate_order(cls, value) -> int:
+        """
+        If and `order` is set explicitly we increment the default anyway. This
+        will ensure default `order` values will have a consistant value related
+        to their delcaration in the config file.
+
+        Due to the order-of-operations used by Pydantic internally we can't use
+        the Field default_factory.
+        """
+
+        inc = NextIncrement()
+        if value is None:
+            value = inc
+        return value
 
     class Config:
         env_prefix = 'foremon_'
@@ -98,6 +125,23 @@ class ForemonConfig(BaseSettings):
             configs.append(obj)
         super().__init__(*args, **kwargs)
 
+    def get_env(self) -> MutableMapping[str, str]:
+        env = os.environ.copy()
+        env.update(self.environment)
+        return env
+
+    def get_configs(self) -> List['ForemonConfig']:
+        """
+        Generator yields all configs in order
+        """
+        configs = [self]
+        ordered: List[ForemonConfig] = []
+        while configs:
+            config = configs.pop(0)
+            configs.extend(config.configs)
+            ordered.append(config)
+        return sorted(ordered, key=lambda c: c.order)
+
 
 ForemonConfig.update_forward_refs()
 
@@ -119,6 +163,10 @@ class PyProjectConfig(BaseSettings):
 
     @classmethod
     def parse_toml(cls, text: str) -> 'PyProjectConfig':
+        # TODO - Do this without a global. We need to reset this to zero each
+        # time a config is reloaded to keep auto-values constant between config
+        # reloads.
+        SetIncrement(0)
         data = toml.loads(text)
         project = cls.parse_obj(data)
         return project
@@ -141,4 +189,5 @@ class ForemonOptions(BaseModel):
     dwell: float = Field(0.1)
 
 
-__all__ = ['PyProjectConfig', 'ToolConfig', 'ForemonConfig', 'Events', 'ForemonOptions']
+__all__ = ['PyProjectConfig', 'ToolConfig',
+           'ForemonConfig', 'Events', 'ForemonOptions']

--- a/foremon/config.py
+++ b/foremon/config.py
@@ -138,6 +138,7 @@ class ForemonOptions(BaseModel):
     use_all: bool = Field(False)
     verbose: bool = Field(False)
     auto_reload: bool = Field(True)
+    dwell:float = Field(0.1)
 
 
 __all__ = ['PyProjectConfig', 'ToolConfig', 'ForemonConfig', 'Events', 'ForemonOptions']

--- a/foremon/debounce.py
+++ b/foremon/debounce.py
@@ -3,29 +3,30 @@ import time
 from asyncio import BaseEventLoop
 from asyncio.events import TimerHandle
 from collections import defaultdict
-from typing import Any, Callable, DefaultDict, List, Optional
+from typing import Any, Callable, DefaultDict, List, Optional, Tuple
 
 from foremon.display import display_error, display_warning
+from foremon.task import ForemonTask
 
 
 class EventContainer:
-    set_at: int
-    args: List[Any]
+    args: Optional[Tuple[ForemonTask, Any]]
     reset_count: int
+    set_at: int
     warn_after: int
 
     def __init__(self) -> None:
         self.set_at = -1
-        self.args = []
+        self.args = None
         self.reset_count = 0
         self.warn_after = 100
 
-    def set(self, args: List[Any]):
+    def set(self, task: ForemonTask, ev: Any):
         if self.set_at != -1:
             self.reset_count += 1
 
         self.set_at = time.time()
-        self.args = args
+        self.args = (task, ev)
 
         if self.reset_count < self.warn_after:
             return
@@ -41,32 +42,39 @@ class Debounce:
     pending_events: DefaultDict
     _scheduled: Optional[TimerHandle]
 
-    def __init__(self, dwell: float, callback: Callable, loop: Optional[BaseEventLoop] = None):
+    def __init__(self,
+                 dwell: float,
+                 callback: Callable[[ForemonTask, Any], None],
+                 loop: Optional[BaseEventLoop] = None):
         self.loop = loop or asyncio.get_event_loop()
         self.callback = callback
         self.dwell = dwell
         self.pending_events = defaultdict(EventContainer)
         self._scheduled = None
 
-    def submit(self, key: str, *args: List[Any]):
+    def submit(self, task: ForemonTask, ev: Any):
         if self.dwell <= 0.0:
-            self.callback(*args)
+            self.callback(task, ev)
         else:
-            self.pending_events[key].set(args)
+            self.pending_events[task.name].set(task, ev)
             if self._scheduled:
                 self._scheduled.cancel()
             self._scheduled = self.loop.call_later(
                 self.dwell, self.drain_events)
 
-    def submit_threadsafe(self, key: str, *args: List[Any]):
-        self.loop.call_soon_threadsafe(self.submit, key, *args)
+    def submit_threadsafe(self, task: ForemonTask, ev: Any):
+        self.loop.call_soon_threadsafe(self.submit, task, ev)
 
     def drain_events(self):
         self._scheduled = None
         containers = list(self.pending_events.values())
         self.pending_events.clear()
 
-        for cont in containers:
+        def get_order(cont: EventContainer):
+            return cont.args[0].config.order
+
+        cont: EventContainer
+        for cont in sorted(containers, key=get_order):
             try:
                 self.callback(*cont.args)
             except Exception as e:

--- a/foremon/debounce.py
+++ b/foremon/debounce.py
@@ -24,7 +24,7 @@ class EventContainer:
         if self.set_at != -1:
             self.reset_count += 1
 
-        self.set_at = time.time_ns()
+        self.set_at = time.time()
         self.args = args
 
         if self.reset_count < self.warn_after:

--- a/foremon/debounce.py
+++ b/foremon/debounce.py
@@ -1,0 +1,71 @@
+import asyncio
+import time
+from asyncio import BaseEventLoop
+from asyncio.events import TimerHandle
+from collections import defaultdict
+from typing import Any, Callable, DefaultDict, List, Optional
+
+from foremon.display import display_warning
+
+
+class EventContainer:
+    set_at: int
+    args: List[Any]
+    reset_count: int
+    warn_after: int
+
+    def __init__(self) -> None:
+        self.set_at = -1
+        self.args = []
+        self.reset_count = 0
+        self.warn_after = 100
+
+    def set(self, args: List[Any]):
+        if self.set_at != -1:
+            self.reset_count += 1
+
+        self.set_at = time.time_ns()
+        self.args = args
+
+        if self.reset_count < self.warn_after:
+            return
+
+        display_warning('detected high events volume - suppressed',
+                        self.reset_count, 'events')
+        self.warn_after += 100
+
+
+class Debounce:
+    callback: Callable
+    dwell = float
+    pending_events: DefaultDict
+    _scheduled: Optional[TimerHandle]
+
+    def __init__(self, dwell: float, callback: Callable, loop: Optional[BaseEventLoop] = None):
+        self.loop = loop or asyncio.get_event_loop()
+        self.callback = callback
+        self.dwell = dwell
+        self.pending_events = defaultdict(EventContainer)
+        self._scheduled = None
+
+    def submit(self, key: str, *args: List[Any]):
+        self.pending_events[key].set(args)
+        if self._scheduled:
+            self._scheduled.cancel()
+        self._scheduled = self.loop.call_later(
+            self.dwell, self.drain_events)
+
+    def submit_threadsafe(self, key: str, *args: List[Any]):
+        self.loop.call_soon_threadsafe(self.submit, key, *args)
+
+    def drain_events(self):
+        self._scheduled = None
+        containers = list(self.pending_events.values())
+        self.pending_events.clear()
+
+        for cont in containers:
+            try:
+                self.callback(*cont.args)
+            except Exception as e:
+                print('drain_events', e)
+                pass

--- a/foremon/debounce.py
+++ b/foremon/debounce.py
@@ -49,11 +49,17 @@ class Debounce:
         self._scheduled = None
 
     def submit(self, key: str, *args: List[Any]):
-        self.pending_events[key].set(args)
-        if self._scheduled:
-            self._scheduled.cancel()
-        self._scheduled = self.loop.call_later(
-            self.dwell, self.drain_events)
+        if self.dwell <= 0.0:
+            try:
+                self.callback(*args)
+            except:
+                pass
+        else:
+            self.pending_events[key].set(args)
+            if self._scheduled:
+                self._scheduled.cancel()
+            self._scheduled = self.loop.call_later(
+                self.dwell, self.drain_events)
 
     def submit_threadsafe(self, key: str, *args: List[Any]):
         self.loop.call_soon_threadsafe(self.submit, key, *args)

--- a/foremon/debounce.py
+++ b/foremon/debounce.py
@@ -5,7 +5,7 @@ from asyncio.events import TimerHandle
 from collections import defaultdict
 from typing import Any, Callable, DefaultDict, List, Optional
 
-from foremon.display import display_warning
+from foremon.display import display_error, display_warning
 
 
 class EventContainer:
@@ -30,9 +30,9 @@ class EventContainer:
         if self.reset_count < self.warn_after:
             return
 
-        display_warning('detected high events volume - suppressed',
-                        self.reset_count, 'events')
         self.warn_after += 100
+        display_warning('detected high event volume - suppressed',
+                        self.reset_count, 'events')
 
 
 class Debounce:
@@ -50,10 +50,7 @@ class Debounce:
 
     def submit(self, key: str, *args: List[Any]):
         if self.dwell <= 0.0:
-            try:
-                self.callback(*args)
-            except:
-                pass
+            self.callback(*args)
         else:
             self.pending_events[key].set(args)
             if self._scheduled:
@@ -73,5 +70,4 @@ class Debounce:
             try:
                 self.callback(*cont.args)
             except Exception as e:
-                print('drain_events', e)
-                pass
+                display_error('drain callback error', e)

--- a/foremon/display.py
+++ b/foremon/display.py
@@ -49,20 +49,20 @@ def colored(*args: str, color: Optional[str] = None):
     return msg
 
 
-def display(msg: str, color: Optional[str] = None):
+def display(*msg: str, color: Optional[str] = None):
     prefix = get_display_name()
     if prefix:
         prefix = '[' + prefix + ']'
-    text = colored(prefix, msg, color=color) + "\n"
+    text = colored(prefix, *msg, color=color) + "\n"
     display_get_writer()(text)
 
 
-def display_warning(msg: str):
-    display(msg, color='yellow')
+def display_warning(*msg: str):
+    display(*msg, color='yellow')
 
 
-def display_info(msg: str):
-    display(msg, color='cyan')
+def display_info(*msg: str):
+    display(*msg, color='cyan')
 
 
 def display_error(msg: str, e: Exception = None):
@@ -74,8 +74,8 @@ def display_error(msg: str, e: Exception = None):
     display(msg, color='red')
 
 def display_success(*msg: Any):
-  display(' '.join(map(str, msg)), 'green')
+  display(*msg, color='green')
 
 def display_debug(*msg: Any):
   if display_verbose():
-    display(' '.join(map(str, msg)), 'blue')
+    display(*msg, color='blue')

--- a/foremon/monitor.py
+++ b/foremon/monitor.py
@@ -81,8 +81,7 @@ class Monitor:
             raise ForemonError(
                 'no valid paths specified, cannot add watch task', errno.ENOENT)
 
-        # callback = partial(self.queue_task_event, task)
-        callback = partial(self.debounce.submit_threadsafe, task.name, task)
+        callback = partial(self.debounce.submit_threadsafe, task)
 
         handler = PatternMatchingEventHandler(
             patterns=conf.patterns,
@@ -134,7 +133,8 @@ class Monitor:
         if task.running:
             task.terminate()
 
-        self.loop.call_soon_threadsafe(self.queue.put_nowait, lambda: self.run_task(task, ev))
+        self.loop.call_soon_threadsafe(
+            self.queue.put_nowait, lambda: self.run_task(task, ev))
 
     async def run_task(self, task: ForemonTask, trigger: Any) -> None:
         if self.is_terminating or self.is_paused:

--- a/foremon/task.py
+++ b/foremon/task.py
@@ -148,7 +148,7 @@ class ScriptTask(ForemonTask):
             try:
                 self.process = await create_subprocess_shell(
                     script, stdout=sys.stdout, stderr=sys.stderr,
-                    shell=True, env=self.config.get_env())
+                    shell=True, env=self.config.get_env(), preexec_fn=os.setsid)
 
                 last_pid = self.process.pid
 
@@ -182,7 +182,8 @@ class ScriptTask(ForemonTask):
             return
         self.pending_signals.append(sig)
         try:
-            self.process.send_signal(sig)
+            gid = os.getpgid(self.process.pid)
+            os.killpg(gid, sig)
         except ProcessLookupError as e:
             # He's dead, Jim
             pass

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     'automation'
   ]),
   classifiers=[
-    'Development Status :: 4 - Beta',
+    'Development Status :: 5 - Production/Stable',
     'Environment :: Console',
     'Intended Audience :: Developers',
     'License :: OSI Approved :: MIT License',

--- a/tests/expect/basic.exp
+++ b/tests/expect/basic.exp
@@ -22,22 +22,8 @@ expect eof
 spawn foremon --version
 expect eof
 
-# Start Test 1
-
-# will trigger test2 later
-spawn bash -c "
-    sleep 4
-    if touch $EXP_TMP/EXPECT_TEST2; then
-        echo `date +%s` - OK - Set trigger $EXP_TMP/EXPECT_TEST2
-    else
-        echo `date +%s` - FAIL - Trigger was not set
-    fi
-"
-expect_after {
-    eof
-}
-
 spawn foremon -V -f $EXP_CONFIG/sanity-check.toml -a test1 -a test2
+set FOREMON $spawn_id
 expect_after eof {
     send_user "\n$LINE\n"
     send_user "[exec date +%s] - DONE - SUCCESS\n"
@@ -65,6 +51,19 @@ expect "clean exit*"
 
 send_user "\n$LINE\n"
 send_user "[exec date +%s] - WORKING - Waiting for file change event ...\n"
+
+# will trigger soon
+spawn bash -c "
+    sleep 1
+    if touch $EXP_TMP/EXPECT_TEST2; then
+        echo `date +%s` - OK - Set trigger $EXP_TMP/EXPECT_TEST2
+    else
+        echo `date +%s` - FAIL - Trigger was not set
+    fi
+"
+set TRIGGER_PROC $spawn_id
+set spawn_id $FOREMON
+
 expect {
     "timeout" {
         send_user "\n$LINE\n"

--- a/tests/expect/basic.exp
+++ b/tests/expect/basic.exp
@@ -8,48 +8,66 @@ catch {set EXP_TMP $env(TEMPDIR)}
 set EXP_CONFIG config
 catch {set EXP_CONFIG $env(CONFIGDIR)}
 
+set COLS [exec tput cols]
+set LINE [exec bash -c "printf '=%.0s' {1..$COLS}"]
+
 set timeout 10
 
 # Cleanup previous runs
 spawn rm -f $EXP_TMP/trigger-1 $EXP_TMP/trigger-2
-expect EOF
+expect eof
 
 # Get version
 spawn foremon --version
-expect EOF
+expect eof
 
 # Start Test 1
 
 # will trigger test2 later
-spawn bash -c "sleep 4; touch $EXP_TMP/EXPECT_TEST2"
+spawn bash -c "
+    sleep 4
+    if touch $EXP_TMP/EXPECT_TEST2; then
+        echo `date +%s` - OK - Set trigger $EXP_TMP/EXPECT_TEST2
+    else
+        echo `date +%s` - FAIL - Trigger was not set
+    fi
+"
+expect_after {
+    eof
+}
 
 spawn foremon -V -f $EXP_CONFIG/sanity-check.toml -a test1 -a test2
 expect_after eof {
-    send_user "\n[exec date +%s] - DONE - SUCCESS\n"
+    send_user "\n$LINE\n"
+    send_user "[exec date +%s] - DONE - SUCCESS\n"
     exit 0
 }
 
-send_user "\n[exec date +%s] - WORKING - Waiting for initial tasks to execute ...\n"
+send_user "\n$LINE\n"
+send_user "[exec date +%s] - WORKING - Waiting for initial tasks to execute ...\n"
 expect "starting"
-expect "trigger-1"
 expect "clean exit"
 expect "clean exit" {
-    send_user "\n[exec date +%s] - WORKING - Sending RESTART\n"
+    send_user "\n$LINE\n"
+    send_user "[exec date +%s] - WORKING - Sending RESTART\n"
     send "rs\n"
 }
 
-send_user "\n[exec date +%s] - WORKING - Waiting for restarted tasks to execute ...\n"
+send_user "\n$LINE\n"
+send_user "[exec date +%s] - WORKING - Waiting for restarted tasks to execute ...\n"
 expect "starting"
-expect "starting"
-expect "trigger*"
 expect "trigger*"
 expect "clean exit*"
+expect "starting"
+expect "trigger*"
 expect "clean exit*"
 
-send_user "\n[exec date +%s] - WORKING - Waiting for file change event ...\n"
+send_user "\n$LINE\n"
+send_user "[exec date +%s] - WORKING - Waiting for file change event ...\n"
 expect {
     "timeout" {
-        send_user "\n[exec date +%s] - FAIL - while waiting for filesystem event to fire\n"
+        send_user "\n$LINE\n"
+        send_user "[exec date +%s] - FAIL - While waiting for filesystem event to fire\n\n"
         exit 1
     }
 
@@ -59,12 +77,14 @@ expect "starting*"
 expect "trigger-2"
 
 expect "clean exit*" {
-    send_user "\n[exec date +%s] - WORKING - Sending exit command ...\n"
+    send_user "\n$LINE\n"
+    send_user "[exec date +%s] - WORKING - Sending exit command ...\n"
     send "exit\n"
     expect "stopping..."
 
     "timeout" {
-        send_user "\n[exec date +%s] - FAIL - foremon did not behave as expected\n"
+        send_user "\n$LINE\n"
+        send_user "[exec date +%s] - FAIL - foremon did not behave as expected\n"
         exit 1
     }
 }

--- a/tests/expect/basic.exp
+++ b/tests/expect/basic.exp
@@ -8,7 +8,8 @@ catch {set EXP_TMP $env(TEMPDIR)}
 set EXP_CONFIG config
 catch {set EXP_CONFIG $env(CONFIGDIR)}
 
-set COLS [exec tput cols]
+set COLS 80
+catch { set COLS [exec tput cols] }
 set LINE [exec bash -c "printf '=%.0s' {1..$COLS}"]
 
 set timeout 10

--- a/tests/expect/docker.sh
+++ b/tests/expect/docker.sh
@@ -15,18 +15,31 @@ fi
 
 cd $root
 
-docker run -it --rm \
-    -e TERM=$TERM \
-    -v $root/config:/config \
-    -v $root/tests:/tests \
-    -v $root/dist:/dist \
-    --entrypoint bash \
-    python:$PYTHON_VERSION \
-    -c '
-apt-get update -y -q
-apt-get install -y -q expect
-pip install /dist/foremon*.tar.gz
-for f in `ls -1 tests/expect/*.exp`; do
-    expect $f
-done
-'
+if test -d dist/; then
+    rm dist/ -rf
+fi
+
+if python -m build; then
+
+    docker run -it --rm \
+        -e TEMPDIR=/tmp \
+        -e TERM=$TERM \
+        -v $root/config:/config \
+        -v $root/tests:/tests \
+        -v $root/dist:/dist \
+        --entrypoint bash \
+        python:$PYTHON_VERSION \
+        -c '
+    apt-get update -y -q
+    apt-get install -y -q expect
+    pip install /dist/foremon*.tar.gz
+    for f in `ls -1 tests/expect/*.exp`; do
+        expect $f
+    done
+    '
+
+    exit $?
+else
+    echo "build failed"
+    exit 1
+fi

--- a/tests/samples/server/__main__.py
+++ b/tests/samples/server/__main__.py
@@ -10,4 +10,4 @@ if __name__ == '__main__':
     try:
         run()
     except KeyboardInterrupt:
-        print('\rstopped')
+        print('\rserver stopped')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -92,6 +92,20 @@ def test_cli_unsafe(noninteractive: MagicMock, cli):
     assert f.config == t.config
 
 
+def test_cli_dwell(noninteractive: MagicMock, cli):
+
+    cli('-d 1.5 -- true')
+    f: Foremon = noninteractive.call_args[0][0]
+    assert f.options.dwell == 1.5
+
+
+def test_cli_dwell_clamps(noninteractive: MagicMock, cli):
+
+    cli('-d -1.5 -- true')
+    f: Foremon = noninteractive.call_args[0][0]
+    assert f.options.dwell == 0.0
+
+
 def test_cli_ignore(noninteractive: MagicMock, cli):
 
     cli('-V --dry-run -i "*.test1" -i "*.test2" -- true')
@@ -139,6 +153,7 @@ def test_cli_guess_module1(noninteractive: MagicMock, cli):
     guess = f.config.scripts[0]
     assert op.basename(sys.executable) + ' -m' in guess
 
+
 def test_cli_guess_module2(noninteractive: MagicMock, cli: CliProg):
 
     arg = get_sample_file('module2') + ":main"
@@ -151,6 +166,7 @@ def test_cli_guess_module2(noninteractive: MagicMock, cli: CliProg):
     guess = f.config.scripts[0]
     assert op.basename(sys.executable) + ' -c' in guess
 
+
 def test_cli_guess_modules_in_env(noninteractive: MagicMock, cli):
 
     cli('pytest --markers')
@@ -159,6 +175,7 @@ def test_cli_guess_modules_in_env(noninteractive: MagicMock, cli):
     assert f
     guess = f.config.scripts[0]
     assert op.basename(sys.executable) + ' -m' in guess
+
 
 def test_cli_config_bad_path(noninteractive, cli, output: CapLines, tempfiles: Tempfiles):
 
@@ -208,7 +225,7 @@ def test_cli_invoke_as_module(mocker: MagicMock):
     name: MagicMock = mocker.MagicMock(name='set_display_name')
     mocker.patch('foremon.display.set_display_name', name, lambda _: None)
 
-    old_name =  get_display_name()
+    old_name = get_display_name()
     from foremon.cli import main
     main()
 

--- a/tests/test_debounce.py
+++ b/tests/test_debounce.py
@@ -1,0 +1,71 @@
+import asyncio
+
+from foremon.debounce import Debounce, EventContainer
+
+from .fixtures import *
+
+
+async def test_debounce_dwell_submit():
+    result = []
+    dwell = 0.1
+    d = Debounce(dwell, result.append)
+    d.submit('x', 'x')
+    d.submit('y', 'y')
+    assert not result
+    await asyncio.sleep(dwell)
+    assert 'x' in result
+    assert 'y' in result
+
+
+async def test_debounce_no_dwell_submit():
+    result = []
+    dwell = -0.1
+    d = Debounce(dwell, result.append)
+    d.submit('x', 'x')
+    d.submit('y', 'y')
+    assert 'x' in result
+    assert 'y' in result
+
+
+async def test_debounce_no_dwell_submit_threadsafe():
+    result = []
+    dwell = -0.1
+    d = Debounce(dwell, result.append)
+    d.submit_threadsafe('x', 'x')
+    d.submit_threadsafe('y', 'y')
+    assert 'x' not in result
+    assert 'y' not in result
+    await asyncio.sleep(0.1)
+    assert 'x' in result
+    assert 'y' in result
+
+async def test_debounce_submit_throws(output: CapLines):
+    def thrower(*args):
+        raise Exception('test')
+    d = Debounce(0.1, thrower)
+    d.submit('a', 'a')
+    await asyncio.sleep(0.1)
+    assert output.stderr_expect('drain callback error.*')
+
+
+async def test_debounce_no_dwell_submit_throws(output: CapLines):
+    def thrower(*args):
+        raise Exception('test')
+    d = Debounce(0.0, thrower)
+    with pytest.raises(Exception):
+        d.submit('a', 'a')
+
+
+async def test_debounce_dwell_submit(output: CapLines):
+    result = []
+    dwell = 0.1
+    d = Debounce(dwell, result.append)
+    for i in range(0, 400):
+        d.submit('x', 'x')
+        d.submit('y', 'y')
+    assert not result
+    await asyncio.sleep(dwell)
+    assert 'x' in result
+    assert 'y' in result
+
+    assert output.stderr_expect('detected high event volume.*')

--- a/tests/test_debounce.py
+++ b/tests/test_debounce.py
@@ -1,68 +1,91 @@
 import asyncio
+from foremon.task import ForemonTask
+from typing import Callable
 
 from foremon.debounce import Debounce, EventContainer
-
+from pytest_mock.plugin import MockerFixture
+from itertools import count
 from .fixtures import *
 
 
-async def test_debounce_dwell_submit():
+@pytest.fixture
+def MockTask(mocker: MockerFixture):
+    incr = count(start=0)
+    def MockFactory(name: str, order = None):
+        inc = next(incr)
+        if order is None:
+            order = inc
+
+        c = mocker.MagicMock()
+        mocker.patch.object(c, 'order', order)
+
+        o = mocker.MagicMock()
+        mocker.patch.object(o, 'name', name)
+        mocker.patch.object(o, 'config', c)
+
+        return o
+
+    return MockFactory
+
+async def test_debounce_dwell_submit(MockTask:Callable[[str], ForemonTask]):
     result = []
     dwell = 0.1
-    d = Debounce(dwell, result.append)
-    d.submit('x', 'x')
-    d.submit('y', 'y')
+    d = Debounce(dwell, lambda *args: result.append(args[1]))
+    d.submit(MockTask('x'), 'x')
+    d.submit(MockTask('y'), 'y')
     assert not result
     await asyncio.sleep(dwell)
     assert 'x' in result
     assert 'y' in result
 
 
-async def test_debounce_no_dwell_submit():
+async def test_debounce_no_dwell_submit(MockTask):
     result = []
     dwell = -0.1
-    d = Debounce(dwell, result.append)
-    d.submit('x', 'x')
-    d.submit('y', 'y')
+    d = Debounce(dwell, lambda *args: result.append(args[1]))
+    d.submit(MockTask('x'), 'x')
+    d.submit(MockTask('y'), 'y')
     assert 'x' in result
     assert 'y' in result
 
 
-async def test_debounce_no_dwell_submit_threadsafe():
+async def test_debounce_no_dwell_submit_threadsafe(MockTask):
     result = []
     dwell = -0.1
-    d = Debounce(dwell, result.append)
-    d.submit_threadsafe('x', 'x')
-    d.submit_threadsafe('y', 'y')
+    d = Debounce(dwell, lambda *args: result.append(args[1]))
+    d.submit_threadsafe(MockTask('x'), 'x')
+    d.submit_threadsafe(MockTask('y'), 'y')
     assert 'x' not in result
     assert 'y' not in result
     await asyncio.sleep(0.1)
     assert 'x' in result
     assert 'y' in result
 
-async def test_debounce_submit_throws(output: CapLines):
+
+async def test_debounce_submit_throws(output: CapLines, MockTask):
     def thrower(*args):
         raise Exception('test')
     d = Debounce(0.1, thrower)
-    d.submit('a', 'a')
+    d.submit(MockTask('a'), 'a')
     await asyncio.sleep(0.1)
     assert output.stderr_expect('drain callback error.*')
 
 
-async def test_debounce_no_dwell_submit_throws(output: CapLines):
+async def test_debounce_no_dwell_submit_throws(output: CapLines, MockTask):
     def thrower(*args):
         raise Exception('test')
     d = Debounce(0.0, thrower)
     with pytest.raises(Exception):
-        d.submit('a', 'a')
+        d.submit(MockTask('a'), 'a')
 
 
-async def test_debounce_dwell_submit(output: CapLines):
+async def test_debounce_dwell_high_volume_submit(output: CapLines, MockTask):
     result = []
     dwell = 0.1
-    d = Debounce(dwell, result.append)
+    d = Debounce(dwell, lambda *args: result.append(args[1]))
     for i in range(0, 400):
-        d.submit('x', 'x')
-        d.submit('y', 'y')
+        d.submit(MockTask('x'), 'x')
+        d.submit(MockTask('y'), 'y')
     assert not result
     await asyncio.sleep(dwell)
     assert 'x' in result


### PR DESCRIPTION
### Added

- CLI `--dwell` option to set delay between event fired and script run.
- Config `order: int` added to sort tasks emitted from debouncer.
- Debouncer allows events to coalesce before firing event that triggers task.
- Warning on `stderr` when high event volumes are preventing scripts from restarting.

### Changed

- Project in `stable/prod` status. 

### Fixed

- Race condition in `expect` test when `sleep` used to trigger events.
- Sub-processes not actually reaped by `terminate()` causes zombie processes.
- Debouncer fires events in random order causing scripts to run ignoring order of config declaration.